### PR TITLE
[1/2] Add a whitelist for location providers outside of /system

### DIFF
--- a/services/core/java/com/android/server/ServiceWatcher.java
+++ b/services/core/java/com/android/server/ServiceWatcher.java
@@ -31,6 +31,7 @@ import android.content.pm.Signature;
 import android.content.res.Resources;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.util.Log;
 import android.util.Slog;
@@ -52,6 +53,7 @@ public class ServiceWatcher implements ServiceConnection {
     private static final boolean D = false;
     public static final String EXTRA_SERVICE_VERSION = "serviceVersion";
     public static final String EXTRA_SERVICE_IS_MULTIUSER = "serviceIsMultiuser";
+    private static final String WHITELIST_PACKAGELIST_PROPERTY = "ro.services.whitelist.packagelist";
 
     private final String mTag;
     private final Context mContext;
@@ -88,12 +90,23 @@ public class ServiceWatcher implements ServiceConnection {
             List<String> initialPackageNames) {
         PackageManager pm = context.getPackageManager();
         ArrayList<HashSet<Signature>> sigSets = new ArrayList<HashSet<Signature>>();
+
+        String whitelistPackagesValue = SystemProperties.get(WHITELIST_PACKAGELIST_PROPERTY,"");
+        String[] whitelistPackagesArray = whitelistPackagesValue.split(",");
+        HashSet<String> whitelistPackagesSet = new HashSet<String>(Arrays.asList(whitelistPackagesArray));
+
         for (int i = 0, size = initialPackageNames.size(); i < size; i++) {
             String pkg = initialPackageNames.get(i);
             try {
                 HashSet<Signature> set = new HashSet<Signature>();
-                Signature[] sigs = pm.getPackageInfo(pkg, PackageManager.MATCH_SYSTEM_ONLY
-                        | PackageManager.GET_SIGNATURES).signatures;
+                Signature[] sigs = null;
+                if(whitelistPackagesSet != null && whitelistPackagesSet.contains(pkg)) {
+                    sigs = pm.getPackageInfo(pkg, PackageManager.GET_SIGNATURES).signatures;
+                    Log.i("ServiceWatcher", pkg + " is whitelisted, ignored PackageManager.MATCH_SYSTEM_ONLY");
+                } else {
+                    sigs = pm.getPackageInfo(pkg, PackageManager.MATCH_SYSTEM_ONLY
+                            | PackageManager.GET_SIGNATURES).signatures;
+                }
                 set.addAll(Arrays.asList(sigs));
                 sigSets.add(set);
             } catch (NameNotFoundException e) {


### PR DESCRIPTION
Based on a patch by danielegobbetti@github:
https://github.com/microg/android_packages_apps_UnifiedNlp/commit/f5a4569e9145d45678b76dc8cb5f4aa582c0ebdb
Additionally, a whitelist for packages is added based on a prop.
With the whitelist, it is possible to selectively disable PackageManager.MATCH_SYSTEM_ONLY when needed.

Change-Id: Ibe99a1ef6ab8c88945f47de95615e1fb869f0cdb