### PR TITLE
StatusBarMobileView: Properly init MobileGroup visibility

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarMobileView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarMobileView.java
@@ -163,7 +163,7 @@ public class StatusBarMobileView extends FrameLayout implements DarkReceiver,
             updateMobileTypeView(StatusBar.USE_OLD_MOBILETYPE);
         }
         setContentDescription(mState.contentDescription);
-        if (!mState.visible) {
+        if (!mState.visible || !mState.provisioned) {
             mMobileGroup.setVisibility(View.GONE);
         } else {
             mMobileGroup.setVisibility(View.VISIBLE);
@@ -187,9 +187,8 @@ public class StatusBarMobileView extends FrameLayout implements DarkReceiver,
 
     private void updateState(MobileIconState state) {
         setContentDescription(state.contentDescription);
-        if (mState.visible != state.visible) {
-            mMobileGroup.setVisibility(state.visible ? View.VISIBLE : View.GONE);
-        }
+        mMobileGroup.setVisibility(state.visible && state.provisioned
+                ? View.VISIBLE : View.GONE);
         if (mState.strengthId != state.strengthId) {
             mMobileDrawable.setLevel(state.strengthId);
         }


### PR DESCRIPTION
* We need to do it so that MobileGroup view visibility
  is initialized properly, otherwise it gets shown if
  you disable one of SIM cards and restart SystemUI,
  change visibility of any status bar icon, toggle
  airplane mode on and off or simply reboot your
  device (assuming the device is using real QCOM
  qti-telephony-common implementation).
* By the way setVisibility() is smart enough to not
  do any 'hard work' when the flags are unchanged so
  we shouldn't see any perf regressions or anything
  like this.
* Fixes:
  - https://gitlab.com/LineageOS/issues/android/issues/294
  - https://gitlab.com/LineageOS/issues/android/issues/437

Change-Id: I7f620836a53b90426fd75d8c1e8b0f6bad6688dd